### PR TITLE
Fix issue UnhandledPromiseRejectionWarning

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -13,4 +13,5 @@ module.exports = (app, options) ->
     autoMigrate = require './' + autoMigrate
     autoMigrate(app, options)
   else
-    Promise.reject(new TypeError 'component not enabled')
+    Promise.resolve().then (res) ->
+      TypeError 'component not enabled'


### PR DESCRIPTION
Fix issue: UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): TypeError: component not enabled.
Returning the promise resolve this issue, however not sure of the impact of this change.